### PR TITLE
update "when" clause of rech.editor.batch.tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 			{
 				"command": "rech.editor.batch.tab",
 				"key": "tab",
-				"when": "editorLangId == bat && !inSnippetMode"
+				"when": "editorLangId == bat && !inSnippetMode && !suggestWidgetVisible"
 			},
 			{
 				"command": "rech.editor.batch.revtab",


### PR DESCRIPTION
Added "!suggestWidgetVisible" to "when" clause of rech.editor.batch.tab to make auto completion by tab work with vscode suggestions. Otherwise auto completion wasn't happening when tab was being pressed.