### PR TITLE
Now also considers .cmd extension as Windows Batch Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rech-editor-batch",
 	"displayName": "Rech Batch",
 	"description": "Edit Batch files with Visual Studio Code",
-	"version": "0.0.16",
+	"version": "0.0.17",
 	"publisher": "rechinformatica",
 	"engines": {
 		"vscode": "^1.35.0"
@@ -46,7 +46,8 @@
 			{
 				"id": "bat",
 				"extensions": [
-					".bat"
+					".bat",
+					".cmd"
 				],
 				"configuration": "./bat.configuration.json"
 			}


### PR DESCRIPTION
This PR fixes #5.

Now also considers .cmd extension as Windows Batch Script